### PR TITLE
Spack reconfig

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "mochi-spack-packages"]
+	path = mochi-spack-packages
+	url = https://github.com/srini009/mochi-spack-packages.git
+	branch = experimental-dewi

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -83,16 +83,31 @@ int main(int argc, char** argv) {
     engine.enable_remote_shutdown();
 
 
-    int instance_id;
+
+
+    int num_instances;
     try {
-        instance_id = std::stoi(std::string(getenv("SOMA_NUM_SERVER_INSTANCES")));
+        num_instances = std::stoi(std::string(getenv("SOMA_NUM_SERVER_INSTANCES")));
     } catch (std::exception e){
-        instance_id = 0;
+        num_instances = 1;
     }
 
+
+    int num_servers_per_instance;
+
+    //If SOMA_NUM_SERVERS_PER_INSTANCE is set, use that to divide the servers into instances
+    //Otherwise, if SOMA_NUM_SERVER_INSTANCES is set, divide the servers into that many instances (if possible)
+    try {
+    	num_servers_per_instance = std::stoi(std::string(getenv("SOMA_NUM_SERVERS_PER_INSTANCE")));
+    } catch (std::exception e){
+        num_servers_per_instance = soma_size/num_instances;
+    }
+
+    int instance_id = soma_rank / num_servers_per_instance;
     
     int soma_instance_rank, soma_instance_size;
     MPI_Comm soma_instance_comm;
+
     MPI_Comm_split(soma_comm, 1000 + instance_id, 0, &soma_instance_comm);
     MPI_Comm_rank(soma_instance_comm, &soma_instance_rank);
     MPI_Comm_size(soma_instance_comm, &soma_instance_size);
@@ -104,7 +119,6 @@ int main(int argc, char** argv) {
     }
 
    
-    int num_instances = std::stoi(std::string(getenv("SOMA_NUM_SERVER_INSTANCES")));
 
     char * filename = getenv("SOMA_SERVER_ADDR_FILE");
 

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -23,7 +23,7 @@ static bool        g_use_progress_thread = false;
 
 static void parse_command_line(int argc, char** argv);
 
-static void setup_admin_nodes(tl::engine engine, std::string server_addr, int rank, int size) {
+static void setup_admin_nodes(tl::engine engine, std::string server_addr, int rank, int size, MPI_Comm comm) {
     ofstream addr_file;
 
     // Initialize the thallium server
@@ -42,7 +42,7 @@ static void setup_admin_nodes(tl::engine engine, std::string server_addr, int ra
 	    }
 	    addr_file.close();
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Barrier(comm);
     }
 
 }
@@ -52,59 +52,63 @@ int main(int argc, char** argv) {
     ofstream addr_file;
     parse_command_line(argc, argv);
     MPI_Barrier(MPI_COMM_WORLD);
-    int rank, size;
-    int key, color;
-    int new_rank;
-
+    
     tl::engine engine(g_address, THALLIUM_SERVER_MODE, g_use_progress_thread, g_num_threads);
     std::vector<snt::Provider> providers;
 
     engine.enable_remote_shutdown();
-    MPI_Comm new_comm;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    if(rank == 0) {
+
+    int instance_id;
+    try {
+        instance_id = std::stoi(std::string(getenv("SOMA_NUM_SERVER_INSTANCES")));
+    } catch (std::exception e){
+        instance_id = 0;
+    }
+
+    int soma_rank, soma_size;
+    int soma_instance_rank, soma_instance_size;
+
+    MPI_Comm soma_comm;
+    MPI_Comm_split(MPI_COMM_WORLD, 900 + instance_id, 0, &soma_comm);
+    MPI_Comm_rank(soma_comm, &soma_rank);
+    MPI_Comm_size(soma_comm, &soma_size);
+
+    MPI_Comm soma_instance_comm;
+    MPI_Comm_split(MPI_COMM_WORLD, 1000 + instance_id, 0, &soma_instance_comm);
+    MPI_Comm_rank(soma_instance_comm, &soma_instance_rank);
+    MPI_Comm_size(soma_instance_comm, &soma_instance_size);
+
+    if(soma_rank == 0) {
 	    addr_file.open(getenv("SOMA_SERVER_ADDR_FILE"), ios::app);
-	    addr_file << size << "\n";
+	    addr_file << soma_size << "\n";
 	    addr_file.close();
     }
 
    
     int num_instances = std::stoi(std::string(getenv("SOMA_NUM_SERVER_INSTANCES")));
 
-    if(num_instances == 1) {
-        for(int i = 0; i < size; i++) {
-	    if(rank == i) {
-		    addr_file.open(getenv("SOMA_SERVER_ADDR_FILE"), ios::app);
-		    addr_file << rank << " " << (std::string)engine.self() << "\n";
-		    addr_file.close();
-	    }
-	    MPI_Barrier(MPI_COMM_WORLD);
-        }
-        MPI_Comm_dup(MPI_COMM_WORLD, &new_comm);
-    } else {
-        key = rank;
-        color = (int)(rank/(size/num_instances));
-        MPI_Comm_split(MPI_COMM_WORLD, color, key, &new_comm);
-        MPI_Comm_rank(new_comm, &new_rank);
+    char * filename = getenv("SOMA_SERVER_ADDR_FILE");
 
-        for(int i = 0; i < size; i++) {
-	    if(rank == i) {
-		    addr_file.open(getenv("SOMA_SERVER_ADDR_FILE"), ios::app);
-		    addr_file << new_rank << " " << (std::string)engine.self() << "\n";
-		    addr_file.close();
-	    }
-	    MPI_Barrier(MPI_COMM_WORLD);
-        }
+    for(int i = 0; i < soma_size; i++) {
+	if(soma_rank == i) {
+	    addr_file.open(getenv("SOMA_SERVER_ADDR_FILE"), ios::app);
+	    addr_file << soma_rank << " " << (std::string)engine.self() << "\n";
+	    addr_file.close();
+	}
+	MPI_Barrier(soma_comm);
     }
-       
-    for(unsigned i=0 ; i < g_num_providers; i++) {
-        providers.emplace_back(engine, i, new_comm);
+      
+    for(size_t i = 0 ; i < g_num_providers; i++) {
+        providers.emplace_back(engine, i, soma_instance_comm);
     }
 
+    //Not sure why this sync is needed...
+    MPI_Barrier(soma_comm);
+    setup_admin_nodes(engine, (std::string)engine.self(), soma_rank, soma_size, soma_comm);
+
+    //Sync with client
     MPI_Barrier(MPI_COMM_WORLD);
-    setup_admin_nodes(engine, (std::string)engine.self(), rank, size);
 
     engine.wait_for_finalize();
     MPI_Finalize();

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,7 +1,13 @@
 spack:
+  packages:
+    mpi:
+      buildable: false
+    openmpi:
+      externals:
+      - spec: openmpi@4.1.2
+        prefix: /appl/spack/v017/install-tree/gcc-11.2.0/openmpi-4.1.2-h6c3ze
+      buildable: false
   specs:
-  - cmake
-  - pkg-config
   - uuid
   - mochi-thallium ^libfabric fabrics=verbs,rxm
   - mochi-abt-io
@@ -19,4 +25,5 @@ spack:
       lib: [LD_LIBRARY_PATH]
       lib64: [LD_LIBRARY_PATH]
   repos:
-  - /users/dewiy/mochi-spack-packages
+  - ./mochi-spack-packages
+

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@ spack:
     openmpi:
       externals:
       - spec: openmpi@4.1.2
-        prefix: /appl/spack/v017/install-tree/gcc-11.2.0/openmpi-4.1.2-h6c3ze
+        prefix: /appl/spack/v017/install-tree/gcc-9.4.0/openmpi-4.1.2-cgr4nz
       buildable: false
   specs:
   - uuid
@@ -26,4 +26,3 @@ spack:
       lib64: [LD_LIBRARY_PATH]
   repos:
   - ./mochi-spack-packages
-


### PR DESCRIPTION
This includes both the spack reconfigure and the server changes.

If this breaks spack on machines other than Mahti, feel free to revert to the earlier config.

Spack:
 * Removed some packages which should be installed by default on most machines (e.g. cmake, pkgconfig)
 * Added mochi-spack-packages as a git submodule so there's no hardcoded path to it anymore
   * after git cloning/git pulling the repo run:
     ```
     git submodule init
     git submodule update
     ```
     and you should be good to go.
 * Added ´mpi´ and ´open-mpi´ as external non-buildable packages, the path here is Mahti-specific, so this won't work on other machines. If you're using a system install of spack, you should be able to remove this part of the config

example/server now:
 * Immediately creates a new communicator just for SOMA
 * Creates a communicator for each instance, just like the old example
 * Initializes MPI with the same thread support as Astaroth, to make sure MPI understands they're all in the same process space
 * Calls MPI_Barrier(MPI_COMM_WORLD) after writing the files out for discovery, syncing with the client